### PR TITLE
fix refactor message handling in ChatContent and HomePage to use trim…

### DIFF
--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -305,7 +305,8 @@ function ChatContent({
     options?: { experimental_attachments?: FileList }
   ) => {
     e.preventDefault();
-    if ((!input || !input.trim()) && !options?.experimental_attachments) return;
+    const content = input.trim();
+    if (!content && !options?.experimental_attachments) return;
 
     // Prevent multiple submissions
     if (isLoading || isUploading) {
@@ -315,7 +316,7 @@ function ChatContent({
     try {
       // Submit the message using AI SDK 5 sendMessage pattern
       sendMessage({
-        text: input,
+        text: content,
         files: options?.experimental_attachments
           ? Array.from(options.experimental_attachments).map((file) => ({
               type: "file" as const,

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -87,7 +87,8 @@ export function HomePage() {
     options?: { experimental_attachments?: FileList }
   ) => {
     e.preventDefault();
-    if (!input?.trim() && !options?.experimental_attachments) return;
+    const content = input.trim();
+    if (!content && !options?.experimental_attachments) return;
 
     // Prevent multiple submissions
     if (isStatusLoading || isUploading) {
@@ -110,7 +111,7 @@ export function HomePage() {
         body: JSON.stringify({
           userId: "user-id",
           title: "New Chat",
-          message: input,
+          message: content,
           modelName: currentModel,
           apiKey: currentProvider?.apiKey,
           baseUrl: currentProvider?.baseUrl,
@@ -127,7 +128,7 @@ export function HomePage() {
 
       // Stash pending message into in-memory context, then navigate.
       setPendingMessage(newChatId, {
-        text: input,
+        text: content,
         files: options?.experimental_attachments
           ? Array.from(options.experimental_attachments).map((file) => ({
               type: "file" as const,

--- a/src/components/prompt-kit/prompt-input.tsx
+++ b/src/components/prompt-kit/prompt-input.tsx
@@ -91,7 +91,11 @@ function PromptInput({
           )}
           onClick={() => textareaRef.current?.focus()}
           onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
+            // Only intercept when the fieldset itself is focused; allow normal typing inside the textarea.
+            if (
+              e.currentTarget === e.target &&
+              (e.key === "Enter" || e.key === " ")
+            ) {
               e.preventDefault();
               textareaRef.current?.focus();
             }


### PR DESCRIPTION
This pull request improves the handling of user input and attachments in the chat and home page components, ensuring that whitespace-only messages are not submitted and that trimmed input is consistently used throughout the codebase. It also refines keyboard event handling in the prompt input component to avoid interfering with normal typing.

**Input handling improvements:**

* Ensured that user input is trimmed before submission and consistently referenced as `content` instead of `input` in both `ChatContent` (`src/components/chat/chat.tsx`) and `HomePage` (`src/components/home-page.tsx`). This prevents messages that are only whitespace from being sent. [[1]](diffhunk://#diff-0bc5e65e839922e38b20c8c4e8ed460f9e98cc8b5ea49af3a30037b339dc27d7L308-R309) [[2]](diffhunk://#diff-a0ce7664568ed3fdc9fc8811fd27f74678dec742b7751b4cef4402237e04b2fbL90-R91)
* Updated message submission logic to use the trimmed `content` variable instead of the raw `input` value when sending messages, storing pending messages, and constructing message payloads. [[1]](diffhunk://#diff-0bc5e65e839922e38b20c8c4e8ed460f9e98cc8b5ea49af3a30037b339dc27d7L318-R319) [[2]](diffhunk://#diff-a0ce7664568ed3fdc9fc8811fd27f74678dec742b7751b4cef4402237e04b2fbL113-R114) [[3]](diffhunk://#diff-a0ce7664568ed3fdc9fc8811fd27f74678dec742b7751b4cef4402237e04b2fbL130-R131)

**Keyboard event handling refinement:**

* Modified the `PromptInput` component (`src/components/prompt-kit/prompt-input.tsx`) to only intercept "Enter" or "Space" key presses when the fieldset itself is focused, allowing normal typing behavior inside the textarea.…med input